### PR TITLE
Add a README.rst, for DFHack docs

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -1,0 +1,15 @@
+==============
+Roses' scripts
+==============
+
+.. todo
+    
+    Properly documenting all of these scripts is going to be a huge job.
+    I feel sorry for whoever that falls to, I really do.
+
+Roses' script collection is one of the biggest modding projects around.
+
+In fact, it's so impressive that we haven't finished documenting it yet.
+Until that's done, try reading through
+`Roses' Bay12 forums thread. <http://www.bay12forums.com/smf/index.php?topic=135597>`_
+


### PR DESCRIPTION
The new build process with Sphinx can pull in other .rst format documentation, and we've got it set up to do this as of DFHack pull 697.

Adding a README means these scripts will be documented with DFHack, as well as distributed with DFHack.

(very very basic, but it gets it in the index and points users in the right direction)
